### PR TITLE
HttpContext.Current != null

### DIFF
--- a/src/NauckIT.PostgreSQLProvider/PgMembershipProvider.cs
+++ b/src/NauckIT.PostgreSQLProvider/PgMembershipProvider.cs
@@ -104,7 +104,7 @@ namespace NauckIT.PostgreSQLProvider
 
             // Check whether we are on a web hosted application or not
             // If we're web hosted use the Web.config; otherwise the application's config file
-            Configuration cfg = HttpContext.Current != null
+            Configuration cfg = HostingEnvironment.IsHosted
                                     ? WebConfigurationManager.OpenWebConfiguration(HostingEnvironment.ApplicationVirtualPath)
                                     : ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
 


### PR DESCRIPTION
...this was breaking the ASP.NET Web Admin tool in .NET 4.0+, so I've changed it to a more appropriate check using HostingEnviornment.IsHosted
